### PR TITLE
Only define the PEAR package if it is not already defined.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,8 +3,9 @@ class pear(
 ) inherits pear::params {
 
   # Install the PEAR package.
-  package { $package:
-    ensure => installed,
+  if !defined(Package[$package]) {
+    package { $package:
+      ensure => installed,
+    }
   }
 }
-


### PR DESCRIPTION
The PEAR package should first check if it has already been defined.  This helps prevent conflicts with other modules which may have already defined the php-pear package.
