### PR TITLE
Use a different character for concatenating the repo and package in orde...

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -147,7 +147,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     # Channel provided
     if source = @resource[:source]
 
-      match = source.match(/^([^\/]+)(?:\/(.*))?$/)
+      match = source.match(/^([^|]+)(?:\|(.*))?$/)
 
       if match
         channel = match[1]
@@ -164,7 +164,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
         source = source + "/#{@resource[:name]}-#{@resource.should(:ensure)}"
       end
 
-      command << source
+      command << channel + '/' + package
 
     # Default channel
     else
@@ -184,7 +184,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     # Channel provided
     if source = @resource[:source]
 
-      match = source.match(/^([^\/]+)(?:\/(.*))?$/)
+      match = source.match(/^([^|]+)(?:\|(.*))?$/)
 
       if match
         channel = match[1]
@@ -201,7 +201,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
         source = source + "/#{@resource[:name]}"
       end
 
-      command << source
+      command << channel + '/' + package
     else
       command << @resource[:name]
     end

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,9 +5,9 @@ define pear::package(
   $version = "latest"
 ) {
   if $version != "latest" {
-    $pear_source = "${repository}/${package}-${version}"
+    $pear_source = "${repository}|${package}-${version}"
   } else {
-    $pear_source = "${repository}/${package}"
+    $pear_source = "${repository}|${package}"
   }
 
   package { "pear-${repository}-${package}":


### PR DESCRIPTION
...r to support repository locations like pear.mydomain.com/directory.

An example of this is:

  pear::package { "PHPUnit_Selenium":
    repository => "saucelabs.github.com/pear",
  }
