### PR TITLE
Fix "Could not match" errors in pear provider

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     when /^PACKAGE/ then return nil
     when /^$/ then return nil
     when /^\(no packages installed\)$/ then return nil
-    when /^(\S+)\s+([.\da-z]+)\s+\S+\n/
+    when /^(\S+)\s+([.\da-z]+)\s+\S+$/
       name = $1
       version = $2
       return {


### PR DESCRIPTION
The pear provisioner was throwing errors reading "Warning: Could not match ...". (listed below) I can't explain why this would work for others but not for me, but I fixed it by modifying the regex. The old regex looked for a newline; the new one uses the "$" end-of-string marker.

This patch may or may not be the best way to solve the problem. Perhaps trim whitespace before running the regex?

```
Warning: Could not match drush   5.9.0   stable

Warning: Could not match Archive_Tar      1.3.7   stable
Warning: Could not match Console_Getopt   1.2.3   stable
Warning: Could not match DB               1.7.13  stable
Warning: Could not match PEAR             1.9.4   stable
Warning: Could not match Structures_Graph 1.0.4   stable
Warning: Could not match XML_RPC          1.5.4   stable
Warning: Could not match XML_Util         1.2.1   stable
Warning: Could not match APC            3.1.9   stable

Warning: Could not match memcache       3.0.8   beta

Warning: Could not match memcached      1.0.0   stable

Warning: Could not match uploadprogress 1.0.3.1 stable
```
