### PR TITLE
Case-insensitive modifier for regexp which matches package versions

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     when /^PACKAGE/ then return nil
     when /^$/ then return nil
     when /^\(no packages installed\)$/ then return nil
-    when /^(\S+)\s+([.\da-z]+)\s+\S+$/
+    when /^(\S+)\s+([.\da-z]+)\s+\S+$/i
       name = $1
       version = $2
       return {


### PR DESCRIPTION
I've had problems with a package Version like this:

vagrant@excellence:~$ pear list
Installed packages, channel pear.php.net:
OLE                      1.0.0RC1 beta

RC could not be matched as only lowercase characters were allowed within the version regexp.
