### PR TITLE
Correctly matches uppercase letters in package version. 

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     when /^PACKAGE/ then return nil
     when /^$/ then return nil
     when /^\(no packages installed\)$/ then return nil
-    when /^(\S+)\s+([.\da-z]+)\s+\S+$/i
+    when /^(\S+)\s+([.\da-zA-Z]+)\s+\S+$/i
       name = $1
       version = $2
       return {


### PR DESCRIPTION
There is at least one case in the pear repository where a package is not matched because of this problem(OLE 1.0.0RC2). 
