### PR TITLE
pear::config fails on empty values

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,6 @@ define pear::config ($property = $title, $value) {
   exec { "pear-config-${property}":
     command => "pear config-set ${property} \"${value}\"",
     path    => ["/bin","/usr/bin","/usr/local/bin"],
-    unless  => "[ $(pear config-get ${property}) = \"${value}\" ]"
+    unless  => "[ \"$(pear config-get ${property})\" = \"${value}\" ]"
   }
 }


### PR DESCRIPTION
`pear::config` fails when the respective `pear config-get` call returns an empty string.