### PR TITLE
Fix bug in parsing versions with numbers at the end such as "1.0.0RC8"

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
     when /^PACKAGE/ then return nil
     when /^$/ then return nil
     when /^\(no packages installed\)$/ then return nil
-    when /^(\S+)\s+([.\da-zA-Z]+)\s+\S+$/i
+    when /^(\S+)\s+([.\da-zA-Z0-9]+)\s+\S+$/i
       name = $1
       version = $2
       return {


### PR DESCRIPTION
A fix for warnings caused by numbers in some package release versions:
warning: Could not match HTTP_WebDAV_Server       1.0.0RC8  beta
warning: Could not match OLE                      1.0.0RC2  beta