### PR TITLE
fix error in format for installing pear sources with puppet7

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,9 +6,9 @@ define pear::package(
   $version = "latest"
 ) {
   if $version != "latest" {
-    $pear_source = "${repository}|${package}-${version}"
+    $pear_source = "${repository}/${package}-${version}"
   } else {
-    $pear_source = "${repository}|${package}"
+    $pear_source = "${repository}/${package}"
   }
 
   package { "pear-${repository}-${package}":


### PR DESCRIPTION
I noticed that this module won't work with puppet7 anymore.
I found a fix for this and it is only a minimal change.

I would be happy if you merge this so this module could be used in the future. 